### PR TITLE
make verbump update git tag as well

### DIFF
--- a/verbump.sh
+++ b/verbump.sh
@@ -8,6 +8,7 @@ fi
 VERSION="${1}.${2}.${3}"
 VERSION_RC="${1}, ${2}, ${3}, 0"
 
+git tag "v$1.$2.$3"
 echo $VERSION > VERSION
 
 sed -i '' -e "s/#define KCT_VERSION .*/#define KCT_VERSION \"$VERSION\"/" {tool,viewer}/version.h


### PR DESCRIPTION
The PKGBUILD also relies on the git tag of the latest commit, so verbump should update the tag as well.
